### PR TITLE
Dockerfile reordering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ RUN apt-get update && \
     apt-get install -y git wget libcurl4-openssl-dev make automake apache2-dev && \
     apt-get clean
 
-# just copy in apache file
-COPY ./files/drupal5s.conf /etc/apache2/sites-enabled/drupal5s.conf
-
 # clone and compile mod_auth_cas since the packaged version doesn't support saml
 RUN cd /usr/local/src &&\
     git clone https://github.com/Jasig/mod_auth_cas.git && \
@@ -20,6 +17,9 @@ RUN ./configure; make; make install
 
 # make sure teh CASCookiePath exists
 RUN mkdir -p /var/cache/apache2/mod_auth_cas/
+
+# just copy in apache file
+COPY ./files/drupal5s.conf /etc/apache2/sites-enabled/drupal5s.conf
 
 # enable the cas module load and config
 COPY ./files/auth_cas.load /etc/apache2/mods-enabled/auth_cas.load

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,14 @@
 FROM welovecloud/apache-php53:latest
 MAINTAINER ccnmtl <ccnmtl-sysadmin@columbia.edu>
 
-RUN apt-get update
+RUN apt-get update && \
+    apt-get install -y git wget libcurl4-openssl-dev make automake apache2-dev && \
+    apt-get clean
 
 # just copy in apache file
 COPY ./files/drupal5s.conf /etc/apache2/sites-enabled/drupal5s.conf
 
 # clone and compile mod_auth_cas since the packaged version doesn't support saml
-RUN apt-get install -y git wget libcurl4-openssl-dev make automake apache2-dev 
 RUN cd /usr/local/src && git clone https://github.com/Jasig/mod_auth_cas.git 
 WORKDIR /usr/local/src/mod_auth_cas
 RUN git checkout b68a2aad

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,11 @@ RUN apt-get update && \
 COPY ./files/drupal5s.conf /etc/apache2/sites-enabled/drupal5s.conf
 
 # clone and compile mod_auth_cas since the packaged version doesn't support saml
-RUN cd /usr/local/src && git clone https://github.com/Jasig/mod_auth_cas.git 
+RUN cd /usr/local/src &&\
+    git clone https://github.com/Jasig/mod_auth_cas.git && \
+		cd mod_auth_cas && \
+		git checkout b68a2aad
 WORKDIR /usr/local/src/mod_auth_cas
-RUN git checkout b68a2aad
 RUN ./configure; make; make install
 
 # make sure teh CASCookiePath exists


### PR DESCRIPTION
Reorder a few things in the Dockerfile.
- combine the apt-get stuff to avoid stale intermediate container issues and clean up cruft
- combine the git commands for a similar reason. I'd also recommend switching over to just wget-ing a tarball from github instead of cloning.
- move the copy of the config file to the end so an edit to the config doesn't cause all the apt-getting and compiling and so on to happen all over again every time. (If the contents of the config file actually somehow affect how that stuff works, than we shouldn't do this, but it seems like it shouldn't).
